### PR TITLE
Parse To: field as array of strings for email action

### DIFF
--- a/src/Nest.Watcher/Domain/Action/EmailAction.cs
+++ b/src/Nest.Watcher/Domain/Action/EmailAction.cs
@@ -14,7 +14,7 @@ namespace Nest
 		[JsonProperty("from")]
 		string From { get; set; }
 		[JsonProperty("to")]
-		string To { get; set; }
+		IEnumerable<string> To { get; set; }
 		[JsonProperty("cc")]
 		string Cc { get; set; }
 		[JsonProperty("bcc")]
@@ -45,7 +45,7 @@ namespace Nest
 	{
 		public string Account { get; set; }
 		public string From { get; set; }
-		public string To { get; set; }
+		public IEnumerable<string> To { get; set; }
 		public string Cc { get; set; }
 		public string Bcc { get; set; }
 		public string ReplyTo { get; set; }

--- a/src/Tests/Nest.Watcher.Tests.Integration/ExecuteWatch/Basic.cs
+++ b/src/Tests/Nest.Watcher.Tests.Integration/ExecuteWatch/Basic.cs
@@ -43,7 +43,7 @@ namespace Nest.Watcher.Tests.Integration.Execute
 					{
 						ScheduledTime = _triggeredDateTime,
 						TriggeredTime = _triggeredDateTime
-                    },
+					},
 					AlternativeInput = new Dictionary<string, object>
 					{
 						{ "foo", "bar" }
@@ -151,7 +151,7 @@ namespace Nest.Watcher.Tests.Integration.Execute
 				.Actions(act => act
 					.Add("email_admin", new EmailAction
 					{
-						To = "someone@domain.host.com",
+						To = new [] { "someone@domain.host.com" },
 						Subject = "404 recently encountered"
 					})
 					.Add("index_action", new IndexAction

--- a/src/Tests/Nest.Watcher.Tests.Integration/ExecuteWatch/InlineWatch.cs
+++ b/src/Tests/Nest.Watcher.Tests.Integration/ExecuteWatch/InlineWatch.cs
@@ -64,7 +64,7 @@ namespace Nest.Watcher.Tests.Integration.Execute
 					.Actions(aas => aas
 						.Add("email_admin", new EmailAction
 						{
-							To = "someone@domain.host.com",
+							To = new [] {"someone@domain.host.com"},
 							Subject = "404 recently encountered"
 						})
 					)
@@ -120,7 +120,7 @@ namespace Nest.Watcher.Tests.Integration.Execute
 						{
 							{ "email_admin", new EmailAction {
 								From = "nest-client@domain.example",
-								To = "someone@domain.host.example",
+								To = new [] {"someone@domain.host.example"},
 								Subject = "404 recently encountered"
 							}}
 						}

--- a/src/Tests/Nest.Watcher.Tests.Integration/GetWatch/Basic.cs
+++ b/src/Tests/Nest.Watcher.Tests.Integration/GetWatch/Basic.cs
@@ -45,7 +45,7 @@ namespace Nest.Watcher.Tests.Integration.Get
 			response.Watch.Condition.Should().NotBeNull();
 			response.Watch.Input.Should().NotBeNull();
 			response.Watch.Actions.Should().NotBeEmpty();
-			response.Watch.Actions.Count().Should().Be(1);
+			response.Watch.Actions.Count().Should().Be(2);
 		}
 	}
 }

--- a/src/Tests/Nest.Watcher.Tests.Integration/IntegrationTests.cs
+++ b/src/Tests/Nest.Watcher.Tests.Integration/IntegrationTests.cs
@@ -63,6 +63,7 @@ namespace Nest.Watcher.Tests.Integration
 				.Condition(c => c.Always())
 				.Actions(a => a
 					.Add("test_index", new IndexAction { Index = "test", DocType = "test2" })
+					.Add("test_email", new EmailAction { To = new [] { "someone@domain.host.com"}, Subject = "404 recently encountered" })
 				)
 			);
 			response.IsValid.Should().BeTrue();

--- a/src/Tests/Nest.Watcher.Tests.Unit/Put/PutActionsJsonTests.cs
+++ b/src/Tests/Nest.Watcher.Tests.Unit/Put/PutActionsJsonTests.cs
@@ -23,7 +23,7 @@ namespace Nest.Watcher.Tests.Unit.Put
 						{
 							account = "account",
 							from = "from",
-							to = "to",
+							to = new [] {"to"},
 							cc = "cc",
 							bcc = "dotnet@test.example",
 							reply_to = "replyto",
@@ -52,7 +52,7 @@ namespace Nest.Watcher.Tests.Unit.Put
 						Priority = EmailPriority.High,
 						ReplyTo = "replyto",
 						Subject = "subject",
-						To = "to",
+						To = new [] {"to"},
 						Transform = new ScriptTransform
 						{
 							Inline = "inline"


### PR DESCRIPTION
Looks like the "to" field can either be a comma-delimited string or an array of strings (https://www.elastic.co/guide/en/watcher/current/actions.html#email-address).  Not sure how to properly model those two options in JSON.NET, but the response of GetWatch formats it as an array of strings, so I've changed the "to" field to be IEnumerable<string>
